### PR TITLE
Add CI workflow to run tests for pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          allow-prereleases: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Create test environment
+        run: |
+          cat <<'ENV' > .env
+          DEBUG=False
+          SECRET_KEY=test-secret-key
+          DB_ENGINE=django.db.backends.sqlite3
+          AWS_ACCESS_KEY_ID=test
+          AWS_SECRET_ACCESS_KEY=test
+          AWS_STORAGE_BUCKET_NAME=test-bucket
+          AWS_S3_ENDPOINT_URL=http://localhost:9000
+          AWS_S3_REGION_NAME=us-east-1
+          ENV
+
+      - name: Run tests
+        run: uv run python manage.py test --verbosity 2


### PR DESCRIPTION
## Summary
- add a pull-request GitHub Actions workflow that provisions Python 3.14 with uv
- install project dependencies via `uv sync --frozen`, seed a minimal `.env`, and run the Django test suite with `uv run`

## Testing
- uv run python manage.py test --verbosity 2

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d1fbd611c8322a28cc86c54a5d645)