### PR TITLE
Add configurable favicon setting and fallback admin favicon

### DIFF
--- a/core/migrations/0028_siteconfiguration_favicon.py
+++ b/core/migrations/0028_siteconfiguration_favicon.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("files", "0001_initial"),
+        ("core", "0027_themeinstall_last_synced_commit"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="siteconfiguration",
+            name="favicon",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="File to use as the site favicon.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="site_favicons",
+                to="files.file",
+            ),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -139,6 +139,14 @@ class ThemeInstall(models.Model):
 class SiteConfiguration(SingletonModel):
     title = models.CharField(max_length=255, default="", blank=True)
     tagline = models.CharField(max_length=1024, default="", blank=True)
+    favicon = models.ForeignKey(
+        File,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="site_favicons",
+        help_text="File to use as the site favicon.",
+    )
     site_author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         null=True,

--- a/core/static/favicon.svg
+++ b/core/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Site favicon">
+  <rect width="64" height="64" rx="14" fill="#0f766e" />
+  <path d="M20 20h24v6H32v18h12v6H20v-6h12V26H20z" fill="#f6f2ec" />
+</svg>

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -5,6 +5,11 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>{{ settings.title }}{% block title %}{% endblock %}</title>
+    {% if settings.favicon_id %}
+    <link rel="icon" href="{{ settings.favicon.file.url }}" />
+    {% else %}
+    <link rel="icon" href="{% static 'favicon.svg' %}" />
+    {% endif %}
 
     {# Theme assets live at themes/<slug>/... #}
     <link rel="stylesheet" href="{% theme_static 'css/theme.css' %}" />

--- a/core/urls.py
+++ b/core/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("favicon.ico", views.favicon, name="favicon"),
     path("page/<slug:slug>/", views.page, name="page"),
     path("robots.txt", views.robots_txt, name="robots_txt"),
     path("sitemap.xml", views.sitemap, name="sitemap"),

--- a/core/views.py
+++ b/core/views.py
@@ -1,7 +1,8 @@
 import markdown
 
 from django.http import HttpResponse
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import render, get_object_or_404, redirect
+from django.templatetags.static import static
 from django.urls import reverse
 
 from .models import Page, SiteConfiguration
@@ -24,6 +25,13 @@ def page(request, slug):
 def robots_txt(request):
     config = SiteConfiguration.get_solo()
     return HttpResponse(config.robots_txt, content_type="text/plain")
+
+
+def favicon(request):
+    config = SiteConfiguration.get_solo()
+    if config.favicon_id and config.favicon and config.favicon.file:
+        return redirect(config.favicon.file.url)
+    return redirect(static("favicon.svg"))
 
 
 def sitemap(request):

--- a/site_admin/forms.py
+++ b/site_admin/forms.py
@@ -269,12 +269,19 @@ class FileForm(forms.ModelForm):
 
 class SiteConfigurationForm(forms.ModelForm):
     active_theme = forms.ChoiceField(required=False, label="Active theme")
+    favicon = forms.ModelChoiceField(
+        queryset=File.objects.none(),
+        required=False,
+        label="Favicon",
+        help_text="Pick an uploaded image to use as the site favicon.",
+    )
 
     class Meta:
         model = SiteConfiguration
         fields = [
             "title",
             "tagline",
+            "favicon",
             "site_author",
             "active_theme",
             "main_menu",
@@ -295,6 +302,9 @@ class SiteConfigurationForm(forms.ModelForm):
                 label = f"{label} ({theme.version})"
             choices.append((theme.slug, label))
         self.fields["active_theme"].choices = choices
+        self.fields["favicon"].queryset = File.objects.filter(kind=File.IMAGE).order_by(
+            "-created_at"
+        )
         for field in self.fields.values():
             if isinstance(field.widget, forms.CheckboxInput):
                 field.widget.attrs.setdefault(

--- a/site_admin/static/site_admin/favicon.svg
+++ b/site_admin/static/site_admin/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Site admin favicon">
+  <rect width="64" height="64" rx="14" fill="#1b1b1b" />
+  <path d="M20 18h24v6H32v6h10c2.2 0 4 1.8 4 4v12H20v-6h18v-4H26c-2.2 0-4-1.8-4-4V18z" fill="#f6f2ec" />
+</svg>

--- a/site_admin/templates/site_admin/base.html
+++ b/site_admin/templates/site_admin/base.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>{% block title %}Admin{% endblock %} · {{ settings.title }}</title>
+    <link rel="icon" href="{% static 'site_admin/favicon.svg' %}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/site_admin/templates/site_admin/login.html
+++ b/site_admin/templates/site_admin/login.html
@@ -1,9 +1,11 @@
+{% load static %}
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Login · Site Admin</title>
+    <link rel="icon" href="{% static 'site_admin/favicon.svg' %}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/site_admin/templates/site_admin/settings/_form.html
+++ b/site_admin/templates/site_admin/settings/_form.html
@@ -34,6 +34,19 @@
       </div>
       <div>
         <label
+          for="{{ form.favicon.id_for_label }}"
+          class="text-xs font-semibold uppercase tracking-wide text-[color:var(--admin-muted)]"
+        >
+          Favicon
+        </label>
+        {{ form.favicon }}
+        {% if form.favicon.help_text %}
+          <p class="mt-1 text-xs text-[color:var(--admin-muted)]">{{ form.favicon.help_text }}</p>
+        {% endif %}
+        {{ form.favicon.errors }}
+      </div>
+      <div>
+        <label
           for="{{ form.site_author.id_for_label }}"
           class="text-xs font-semibold uppercase tracking-wide text-[color:var(--admin-muted)]"
         >


### PR DESCRIPTION
### Motivation
- The site was missing a favicon and returning a top 404 for `/favicon.ico`, so provide a configurable site favicon to avoid that and allow admins to pick an uploaded file. 
- The admin UI should have a stable, non-configurable favicon different from the public site. 

### Description
- Add a `favicon` field to `SiteConfiguration` as `File` FK (`SiteConfiguration.favicon`) and include a migration `core/migrations/0028_siteconfiguration_favicon.py` to add the DB field. 
- Expose the favicon selection in the admin settings via `site_admin/forms.py` and render the field in `site_admin/templates/site_admin/settings/_form.html` with a queryset limited to image files. 
- Serve the favicon via a new view `favicon` (added in `core/views.py`) and route `path('favicon.ico', views.favicon, name='favicon')` in `core/urls.py` which redirects to the configured file URL or falls back to the bundled `core/static/favicon.svg`. 
- Add default static favicon assets `core/static/favicon.svg` for the public site and `site_admin/static/site_admin/favicon.svg` and wire the admin templates (`site_admin/templates/site_admin/base.html` and `site_admin/templates/site_admin/login.html`) to use the admin favicon. 

### Testing
- Attempted to run migrations with `uv run manage.py migrate`, which failed due to a missing `SECRET_KEY` environment variable, so migrations were not applied in the local run. 
- Static assets and templates were added and compiled into the commit; no automated Django tests were run in this environment due to the above configuration error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69575f5d07988322ae019621fcbfe564)