### PR TITLE
Add redirect creation shortcuts to analytics and path suggestions for redirect form

### DIFF
--- a/site_admin/templates/site_admin/analytics/index.html
+++ b/site_admin/templates/site_admin/analytics/index.html
@@ -143,6 +143,7 @@
               <th scope="col" class="px-4 py-3">Path</th>
               <th scope="col" class="px-4 py-3">Status</th>
               <th scope="col" class="px-4 py-3">Count</th>
+              <th scope="col" class="px-4 py-3">Action</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-[color:var(--admin-border)]">
@@ -151,10 +152,22 @@
                 <td class="px-4 py-3 text-[color:var(--admin-ink)]">{{ row.path|default:"(unknown)" }}</td>
                 <td class="px-4 py-3 text-[color:var(--admin-ink)]">{{ row.response_status_code|default:"-" }}</td>
                 <td class="px-4 py-3 text-[color:var(--admin-ink)]">{{ row.count }}</td>
+                <td class="px-4 py-3">
+                  {% if row.response_status_code == 404 and row.path %}
+                    <a
+                      href="{% url 'site_admin:redirect_create' %}?from={{ row.path|urlencode }}"
+                      class="rounded-full border border-[color:var(--admin-border)] px-3 py-1 text-xs font-semibold text-[color:var(--admin-ink)] transition hover:bg-[color:var(--admin-bg)]"
+                    >
+                      Create redirect
+                    </a>
+                  {% else %}
+                    <span class="text-xs text-[color:var(--admin-muted)]">—</span>
+                  {% endif %}
+                </td>
               </tr>
             {% empty %}
               <tr>
-                <td colspan="3" class="px-4 py-3 text-[color:var(--admin-muted)]">No error responses recorded.</td>
+                <td colspan="4" class="px-4 py-3 text-[color:var(--admin-muted)]">No error responses recorded.</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/site_admin/templates/site_admin/redirects/_form.html
+++ b/site_admin/templates/site_admin/redirects/_form.html
@@ -29,8 +29,17 @@
       To path
     </label>
     {{ form.to_path }}
+    {% if path_suggestions %}
+      <datalist id="redirect-path-options">
+        {% for path in path_suggestions %}
+          <option value="{{ path }}"></option>
+        {% endfor %}
+      </datalist>
+    {% endif %}
     {{ form.to_path.errors }}
-    <p class="mt-1 text-xs text-[color:var(--admin-muted)]">Use a path or full URL.</p>
+    <p class="mt-1 text-xs text-[color:var(--admin-muted)]">
+      Use a path or full URL. Start typing to search known site paths.
+    </p>
   </div>
   <div>
     <label


### PR DESCRIPTION
### Motivation
- Provide a faster workflow to fix frequent 404s by surfacing a quick action from the analytics dashboard. 
- Prefill the redirect form when creating a redirect from an analytics row to reduce manual entry. 
- Help authors choose valid targets by offering searchable path suggestions gathered from the site. 
- Improve discoverability of site paths when composing a redirect target.

### Description
- Added `_redirect_path_suggestions()` in `site_admin/views.py` to gather site paths from pages, published posts, and menu items and return a sorted suggestions list. 
- Updated `redirect_edit` in `site_admin/views.py` to accept `from`/`to` query parameters for initial form values, attach a `datalist` via the `to_path` field widget, and pass `path_suggestions` to the template. 
- Added an "Action" column to `site_admin/templates/site_admin/analytics/index.html` with a "Create redirect" button for `404` rows that links to the redirect create page with the `from` parameter prefilled. 
- Enhanced `site_admin/templates/site_admin/redirects/_form.html` to render a `<datalist id="redirect-path-options">` using `path_suggestions` and updated the helper text to indicate searchable site paths.

### Testing
- Attempted to start the dev server with `uv run manage.py runserver`, but it failed due to the `SECRET_KEY` environment variable not being set, so interactive verification was not possible. 
- No automated unit tests were executed as part of this change because the environment prevented running the server/tests. 
- The changes are limited to views and templates and include only non-breaking additions to context and form rendering. 
- Manual QA is recommended in a local environment with `SECRET_KEY` set and `uv run manage.py runserver` to verify the analytics link prefill and datalist behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957607f0d7c8322bcfdb2c4d8687f33)