### PR TITLE
Skip Bridgy publish for likes/replies/reposts

### DIFF
--- a/blog/templates/blog/bridgy_publish_links.html
+++ b/blog/templates/blog/bridgy_publish_links.html
@@ -1,16 +1,18 @@
-{% if settings.bridgy_publish_bluesky or settings.bridgy_publish_flickr or settings.bridgy_publish_github or settings.bridgy_publish_mastodon %}
-  <div class="bridgy-publish-links" hidden aria-hidden="true">
-    {% if settings.bridgy_publish_bluesky %}
-      <a href="https://brid.gy/publish/bluesky" class="u-bridgy-omit-link" tabindex="-1"></a>
-    {% endif %}
-    {% if settings.bridgy_publish_flickr %}
-      <a href="https://brid.gy/publish/flickr" class="u-bridgy-omit-link" tabindex="-1"></a>
-    {% endif %}
-    {% if settings.bridgy_publish_github %}
-      <a href="https://brid.gy/publish/github" class="u-bridgy-omit-link" tabindex="-1"></a>
-    {% endif %}
-    {% if settings.bridgy_publish_mastodon %}
-      <a href="https://brid.gy/publish/mastodon" class="u-bridgy-omit-link" tabindex="-1"></a>
-    {% endif %}
-  </div>
+{% if post and post.kind != post.LIKE and post.kind != post.REPLY and post.kind != post.REPOST %}
+  {% if settings.bridgy_publish_bluesky or settings.bridgy_publish_flickr or settings.bridgy_publish_github or settings.bridgy_publish_mastodon %}
+    <div class="bridgy-publish-links" hidden aria-hidden="true">
+      {% if settings.bridgy_publish_bluesky %}
+        <a href="https://brid.gy/publish/bluesky" class="u-bridgy-omit-link" tabindex="-1"></a>
+      {% endif %}
+      {% if settings.bridgy_publish_flickr %}
+        <a href="https://brid.gy/publish/flickr" class="u-bridgy-omit-link" tabindex="-1"></a>
+      {% endif %}
+      {% if settings.bridgy_publish_github %}
+        <a href="https://brid.gy/publish/github" class="u-bridgy-omit-link" tabindex="-1"></a>
+      {% endif %}
+      {% if settings.bridgy_publish_mastodon %}
+        <a href="https://brid.gy/publish/mastodon" class="u-bridgy-omit-link" tabindex="-1"></a>
+      {% endif %}
+    </div>
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
Guard Bridgy publish links and webmentions so they only apply to non-like/reply/repost posts. Also suppress webmention failure logging during tests to reduce noise.