### PR TITLE
Performance and cost improvements: Redis cache, leaner Celery, feed filters

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -102,7 +102,6 @@ INSTALLED_APPS = [
     "solo",
     "storages",
     "django_celery_beat",
-    "django_celery_results",
     "encrypted_model_fields",
 ]
 
@@ -142,11 +141,24 @@ TEMPLATES = [
         "DIRS": [],
         "APP_DIRS": False,
         "OPTIONS": {
-            "loaders": [
-                "core.template_loaders.ThemeTemplateLoader",
-                "django.template.loaders.filesystem.Loader",
-                "django.template.loaders.app_directories.Loader",
-            ],
+            "loaders": (
+                [
+                    "core.template_loaders.ThemeTemplateLoader",
+                    "django.template.loaders.filesystem.Loader",
+                    "django.template.loaders.app_directories.Loader",
+                ]
+                if DEBUG or RUNNING_TESTS
+                else [
+                    (
+                        "django.template.loaders.cached.Loader",
+                        [
+                            "core.template_loaders.ThemeTemplateLoader",
+                            "django.template.loaders.filesystem.Loader",
+                            "django.template.loaders.app_directories.Loader",
+                        ],
+                    )
+                ]
+            ),
             "builtins": [
                 "core.templatetags.theme",
                 "site_admin.templatetags.site_admin_tags",
@@ -225,12 +237,29 @@ USE_I18N = True
 USE_TZ = True
 
 # ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+if RUNNING_TESTS:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": env("CACHE_URL", default="redis://localhost:6379/1"),
+        }
+    }
+
+# ---------------------------------------------------------------------------
 # Celery
 # ---------------------------------------------------------------------------
 
 CELERY_BROKER_URL = env("CELERY_BROKER_URL", default="redis://localhost:6379/0")
-CELERY_RESULT_BACKEND = "django-db"
-CELERY_RESULT_EXTENDED = True  # stores task_name, worker, date_created, etc.
+CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default="redis://localhost:6379/2")
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,5 +1,6 @@
 import markdown
 
+from django.core.cache import cache
 from django.urls import NoReverseMatch, reverse
 from django.utils.safestring import mark_safe
 from django.db.models import Q
@@ -106,6 +107,11 @@ def interactions_counts(request):
             "admin_profile_initials": "",
         }
 
+    cache_key = f"interactions_counts_{user.pk}"
+    cached_result = cache.get(cache_key)
+    if cached_result is not None:
+        return cached_result
+
     host = request.get_host()
     if not host:
         return {
@@ -141,9 +147,11 @@ def interactions_counts(request):
         .filter(target_query)
         .count()
     )
-    return {
+    result = {
         "interactions_pending_count": pending_comments + pending_webmentions,
         "admin_profile_photo_url": hcard.primary_photo_url if hcard else "",
         "admin_profile_display_name": display_name,
         "admin_profile_initials": initials,
     }
+    cache.set(cache_key, result, 30)
+    return result

--- a/mastodon_integration/tasks.py
+++ b/mastodon_integration/tasks.py
@@ -216,7 +216,7 @@ def publish_post_to_mastodon(self, post_id: int):
         close_old_connections()
 
 
-@shared_task
+@shared_task(ignore_result=True)
 def poll_mastodon_timeline():
     """
     Fetch the Mastodon home timeline since the last seen status ID and write
@@ -310,7 +310,7 @@ def poll_mastodon_timeline():
     close_old_connections()
 
 
-@shared_task
+@shared_task(ignore_result=True)
 def poll_mastodon_notifications():
     """
     Fetch Mastodon notifications since the last seen notification ID.

--- a/microsub/tasks.py
+++ b/microsub/tasks.py
@@ -99,7 +99,7 @@ def poll_subscription(self, sub_id: int, *, force: bool = False, doctor: bool = 
     return {"new": new_count, "updated": updated_count, "url": sub.url}
 
 
-@shared_task
+@shared_task(ignore_result=True)
 def poll_microsub_feeds() -> None:
     from microsub.models import Subscription
 

--- a/microsub/views.py
+++ b/microsub/views.py
@@ -615,6 +615,24 @@ class MicrosubView(View):
         if source_url:
             qs = qs.filter(source_url=source_url)
 
+        author_url = normalize_profile_url(request.GET.get("author", ""))
+        if author_url:
+            qs = qs.filter(author_url=author_url)
+
+        categories = normalize_repeated_values(request.GET.getlist("category"))
+        if categories:
+            qs = qs.filter(search_categories__value__in=categories).distinct()
+
+        kinds = normalize_repeated_values(request.GET.getlist("kind"))
+        if kinds:
+            kind_query = Q()
+            for kind in kinds:
+                field_name = KIND_FIELD_MAP.get(kind)
+                if field_name:
+                    kind_query |= Q(**{field_name: True})
+            if kind_query:
+                qs = qs.filter(kind_query)
+
         qs = _apply_paging(
             qs,
             before_cursor=request.GET.get("before", ""),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "Mastodon.py>=1.8",
   "django-encrypted-model-fields>=0.6",
   "requests>=2.32.5",
-  "django-celery-results>=2.5",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -54,7 +54,6 @@ dependencies = [
     { name = "celery", extra = ["redis"] },
     { name = "django" },
     { name = "django-celery-beat" },
-    { name = "django-celery-results" },
     { name = "django-debug-toolbar" },
     { name = "django-encrypted-model-fields" },
     { name = "django-environ" },
@@ -86,7 +85,6 @@ requires-dist = [
     { name = "celery", extras = ["redis"], specifier = ">=5.3" },
     { name = "django", specifier = ">=5.2.7" },
     { name = "django-celery-beat", specifier = ">=2.7" },
-    { name = "django-celery-results", specifier = ">=2.5" },
     { name = "django-debug-toolbar", specifier = ">=6.2.0" },
     { name = "django-encrypted-model-fields", specifier = ">=0.6" },
     { name = "django-environ", specifier = ">=0.12.0" },
@@ -395,19 +393,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/45/fc97bc1d9af8e7dc07f1e37044d9551a30e6793249864cef802341e2e3a8/django_celery_beat-2.9.0.tar.gz", hash = "sha256:92404650f52fcb44cf08e2b09635cb1558327c54b1a5d570f0e2d3a22130934c", size = 177667, upload-time = "2026-02-28T16:45:34.749Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/ae/9befa7ae37f5e5c41be636a254fcf47ff30dd5c88bd115070e252f6b9162/django_celery_beat-2.9.0-py3-none-any.whl", hash = "sha256:4a9e5ebe26d6f8d7215e1fc5c46e466016279dc102435a28141108649bdf2157", size = 105013, upload-time = "2026-02-28T16:45:32.822Z" },
-]
-
-[[package]]
-name = "django-celery-results"
-version = "2.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "celery" },
-    { name = "django" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/b5/9966c28e31014c228305e09d48b19b35522a8f941fe5af5f81f40dc8fa80/django_celery_results-2.6.0.tar.gz", hash = "sha256:9abcd836ae6b61063779244d8887a88fe80bbfaba143df36d3cb07034671277c", size = 83985, upload-time = "2025-04-10T08:23:52.677Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/da/70f0f3c5364735344c4bc89e53413bcaae95b4fc1de4e98a7a3b9fb70c88/django_celery_results-2.6.0-py3-none-any.whl", hash = "sha256:b9ccdca2695b98c7cbbb8dea742311ba9a92773d71d7b4944a676e69a7df1c73", size = 38351, upload-time = "2025-04-10T08:23:49.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Wire Redis as Django cache backend** — adds `CACHES` config using Django's built-in `RedisCache` (db 1, overridable via `CACHE_URL`). The existing token-introspection and webmention-source caches were calling `cache.set/get` but silently hitting per-process `LocMemCache`; now they actually share state across Gunicorn workers.
- **Celery result backend → Redis** — switches from `django-db` (writing a Postgres row on every task execution) to Redis (db 2, overridable via `CELERY_RESULT_BACKEND`). Removes the `django-celery-results` dependency entirely. Existing `django_celery_results_*` tables in the DB are harmless orphans and can be dropped at leisure.
- **`ignore_result=True` on scheduled polling tasks** — `poll_microsub_feeds`, `poll_mastodon_timeline`, and `poll_mastodon_notifications` never return meaningful values, so their results are no longer stored in any backend.
- **Cached template loaders in production** — wraps the loader chain in `django.template.loaders.cached.Loader` when `DEBUG=False`. Theme changes already call `clear_template_caches()` so this is safe.
- **Cache `interactions_counts` context processor** — eliminates 3 uncached DB queries (HCard + Comment count + Webmention count) on every admin page load by caching per user for 30 seconds.
- **Microsub timeline filters** — `GET /microsub?action=timeline` now accepts `author=<url>`, `category=<tag>` (repeatable), and `kind=<kind>` (repeatable: `like`, `repost`, `bookmark`, `reply`, `checkin`, `photo`, `video`, `audio`). Closes vtodo task #46.

## Deployment notes

Add `CACHE_URL=redis://<host>:6379/1` to your production env (defaults to `redis://localhost:6379/1`). The Celery result backend defaults to db 2 on the same Redis host — override with `CELERY_RESULT_BACKEND` if needed.